### PR TITLE
Restrict JSON payload size

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ const upload = multer({
 });
 
 app.use(express.static(path.join(__dirname, 'public')));
-app.use(express.json());
+app.use(express.json({ limit: '1mb' })); // Ajuste o limite conforme a necessidade real do aplicativo
 app.use(helmet());
 
 app.use(cors({


### PR DESCRIPTION
## Summary
- limit express JSON body parsing to 1mb

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68960c940ee08326aa3a8cf9abf5aaae