### PR TITLE
Validate socket ID before emitting progress updates

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,6 +74,9 @@ app.post('/api/agrupar', upload.single('keywordFile'), async (req, res) => {
   }
 
   const socketId = req.body.socketId; // Receber socketId do cliente
+  if (socketId && !io.sockets.sockets.has(socketId)) {
+    return res.status(400).json({ error: 'Socket ID inválido' });
+  }
   
   const results = [];
   
@@ -99,7 +102,7 @@ app.post('/api/agrupar', upload.single('keywordFile'), async (req, res) => {
         const estimatedTime = Math.ceil(results.length / 60);
         
         // Enviar atualização inicial
-        if (socketId) {
+        if (socketId && io.sockets.sockets.has(socketId)) {
           io.to(socketId).emit('progress', {
             message: `Iniciando análise de ${results.length} palavras-chave... (Tempo estimado: ~${estimatedTime} minuto${estimatedTime > 1 ? 's' : ''})`,
             progress: 0,
@@ -121,7 +124,7 @@ app.post('/api/agrupar', upload.single('keywordFile'), async (req, res) => {
           }
 
           // Enviar atualização antes de buscar
-          if (socketId) {
+          if (socketId && io.sockets.sockets.has(socketId)) {
             io.to(socketId).emit('progress', {
               message: `[${i + 1}/${results.length}] Analisando: "${keywordText}"`,
               progress: Math.round((i / results.length) * 100),
@@ -143,7 +146,7 @@ app.post('/api/agrupar', upload.single('keywordFile'), async (req, res) => {
           console.log(`📊 Progresso: ${progress}% (${i + 1}/${results.length})`);
           
           // Enviar atualização após buscar
-          if (socketId) {
+          if (socketId && io.sockets.sockets.has(socketId)) {
             io.to(socketId).emit('progress', {
               message: `✓ Concluído: "${keywordText}"`,
               progress: progress,
@@ -157,7 +160,7 @@ app.post('/api/agrupar', upload.single('keywordFile'), async (req, res) => {
         console.log('✅ Processamento concluído!');
         
         // Enviar atualização de agrupamento
-        if (socketId) {
+        if (socketId && io.sockets.sockets.has(socketId)) {
           io.to(socketId).emit('progress', {
             message: 'Agrupando palavras-chave similares...',
             progress: 100


### PR DESCRIPTION
## Summary
- ensure `/api/agrupar` checks that a provided socket ID exists before proceeding
- guard progress notifications by verifying the socket is connected before emitting

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68960c967e6483269cf9a8707d87c686