### PR TITLE
Configure Helmet CSP with self default

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,6 +47,15 @@ const upload = multer({
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());
 app.use(helmet());
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", 'https://fonts.googleapis.com'],
+      fontSrc: ["'self'", 'https://fonts.gstatic.com']
+    }
+  })
+);
 
 app.use(cors({
   origin: allowedOrigins,


### PR DESCRIPTION
## Summary
- configure Helmet content security policy with `default-src 'self'` and allow Google Fonts

## Testing
- `NODE_ENV=development node server.js`
- `NODE_ENV=production node server.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68960c991a48832687f5a748ade79b7b